### PR TITLE
fix init.asdf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ init.asdf:
 	git clone https://github.com/asdf-vm/asdf.git ~/.asdf
 	echo '. "${HOME}/.asdf/asdf.sh"' > ~/.bashrc
 	. ~/.bashrc
+	asdf version
 
 init.tools:
 	sudo apt update
@@ -44,6 +45,8 @@ init.tools:
 	asdf plugin add alp
 	asdf install alp `asdf list-all alp | tail -1`
 	asdf global alp `asdf list-all alp | tail -1`
+	pt-query-digest --version
+	alp --version
 
 survey.slowlog:
 	sudo pt-query-digest /var/log/mysql/mysql-slow.log | \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ init.config:
 
 init.asdf:
 	git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-	echo '. "$(HOME)/.asdf/asdf.sh"' > ~/.bashrc
+	echo '. "${HOME}/.asdf/asdf.sh"' > ~/.bashrc
 	. ~/.bashrc
 
 init.tools:

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ ssh -T git@github.com
 cp -prf path/to/webapp path/to/webapp_bak
 
 cd path/to/go
-make init.config
-make init.asdf
-make init.tools log.init
+make init
 ```
 
 その後


### PR DESCRIPTION
asdfのインストール時にbashrcに埋める$HOMEのエスケープがうまくいってなかったので、直してmake init一発で通るようにした。


```
$ make init
mkdir -p ./conf
mkdir -p ./conf/nginx
mkdir -p ./conf/mysql
mkdir -p ./conf/nginx/sites-enabled
mkdir -p ./conf/mysql/conf.d
cp /etc/nginx/nginx.conf ./conf/nginx/nginx.conf
cp /etc/nginx/sites-enabled/* ./conf/nginx/sites-enabled/
cp /etc/mysql/conf.d/*.cnf ./conf/mysql/conf.d/
git clone https://github.com/asdf-vm/asdf.git ~/.asdf
Cloning into '/home/isucon/.asdf'...
remote: Enumerating objects: 8802, done.
remote: Counting objects: 100% (1882/1882), done.
remote: Compressing objects: 100% (339/339), done.
remote: Total 8802 (delta 1637), reused 1624 (delta 1539), pack-reused 6920 (from 1)
Receiving objects: 100% (8802/8802), 3.25 MiB | 30.81 MiB/s, done.
Resolving deltas: 100% (5285/5285), done.
echo '. "/home/isucon/.asdf/asdf.sh"' > ~/.bashrc
. ~/.bashrc
sudo apt update
Hit:1 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Get:2 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Hit:3 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:4 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Hit:5 http://repo.powerdns.com/ubuntu jammy-auth-48 InRelease
Fetched 257 kB in 1s (172 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
76 packages can be upgraded. Run 'apt list --upgradable' to see them.
sudo apt-get install -y percona-toolkit unzip
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  gdb libbabeltrace1 libboost-regex1.74.0 libc6-dbg libdbd-mysql-perl libdbi-perl libdebuginfod-common libdebuginfod1 libipt2 libsource-highlight-common
  libsource-highlight4v5
Suggested packages:
  gdb-doc gdbserver libmldbm-perl libnet-daemon-perl libsql-statement-perl zip
The following NEW packages will be installed:
  gdb libbabeltrace1 libboost-regex1.74.0 libc6-dbg libdbd-mysql-perl libdbi-perl libdebuginfod-common libdebuginfod1 libipt2 libsource-highlight-common
  libsource-highlight4v5 percona-toolkit unzip
0 upgraded, 13 newly installed, 0 to remove and 76 not upgraded.
Need to get 20.6 MB of archives.
After this operation, 45.7 MB of additional disk space will be used.
Get:1 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libdebuginfod-common all 0.186-1build1 [7878 B]
Get:2 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libbabeltrace1 amd64 1.5.8-2build1 [160 kB]
Get:3 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libdebuginfod1 amd64 0.186-1build1 [12.7 kB]
Get:4 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libipt2 amd64 2.0.5-1 [46.4 kB]
Get:5 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libsource-highlight-common all 3.1.9-4.1build2 [64.5 kB]
Get:6 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libboost-regex1.74.0 amd64 1.74.0-14ubuntu3 [511 kB]
Get:7 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libsource-highlight4v5 amd64 3.1.9-4.1build2 [207 kB]
Get:8 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy-updates/main amd64 gdb amd64 12.1-0ubuntu1~22.04.2 [3920 kB]
Get:9 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/main amd64 libdbi-perl amd64 1.643-3build3 [741 kB]
Get:10 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libdbd-mysql-perl amd64 4.050-5ubuntu0.22.04.1 [87.6 kB]
Get:11 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy/universe amd64 percona-toolkit all 3.2.1-1 [896 kB]
Get:12 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy-updates/main amd64 unzip amd64 6.0-26ubuntu3.2 [175 kB]
Get:13 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libc6-dbg amd64 2.35-0ubuntu3.8 [13.8 MB]
Fetched 20.6 MB in 0s (81.0 MB/s)
Preconfiguring packages ...
Selecting previously unselected package libdebuginfod-common.
(Reading database ... 103571 files and directories currently installed.)
Preparing to unpack .../00-libdebuginfod-common_0.186-1build1_all.deb ...
Unpacking libdebuginfod-common (0.186-1build1) ...
Selecting previously unselected package libbabeltrace1:amd64.
Preparing to unpack .../01-libbabeltrace1_1.5.8-2build1_amd64.deb ...
Unpacking libbabeltrace1:amd64 (1.5.8-2build1) ...
Selecting previously unselected package libdebuginfod1:amd64.
Preparing to unpack .../02-libdebuginfod1_0.186-1build1_amd64.deb ...
Unpacking libdebuginfod1:amd64 (0.186-1build1) ...
Selecting previously unselected package libipt2.
Preparing to unpack .../03-libipt2_2.0.5-1_amd64.deb ...
Unpacking libipt2 (2.0.5-1) ...
Selecting previously unselected package libsource-highlight-common.
Preparing to unpack .../04-libsource-highlight-common_3.1.9-4.1build2_all.deb ...
Unpacking libsource-highlight-common (3.1.9-4.1build2) ...
Selecting previously unselected package libboost-regex1.74.0:amd64.
Preparing to unpack .../05-libboost-regex1.74.0_1.74.0-14ubuntu3_amd64.deb ...
Unpacking libboost-regex1.74.0:amd64 (1.74.0-14ubuntu3) ...
Selecting previously unselected package libsource-highlight4v5.
Preparing to unpack .../06-libsource-highlight4v5_3.1.9-4.1build2_amd64.deb ...
Unpacking libsource-highlight4v5 (3.1.9-4.1build2) ...
Selecting previously unselected package gdb.
Preparing to unpack .../07-gdb_12.1-0ubuntu1~22.04.2_amd64.deb ...
Unpacking gdb (12.1-0ubuntu1~22.04.2) ...
Selecting previously unselected package libdbi-perl:amd64.
Preparing to unpack .../08-libdbi-perl_1.643-3build3_amd64.deb ...
Unpacking libdbi-perl:amd64 (1.643-3build3) ...
Selecting previously unselected package libdbd-mysql-perl:amd64.
Preparing to unpack .../09-libdbd-mysql-perl_4.050-5ubuntu0.22.04.1_amd64.deb ...
Unpacking libdbd-mysql-perl:amd64 (4.050-5ubuntu0.22.04.1) ...
Selecting previously unselected package percona-toolkit.
Preparing to unpack .../10-percona-toolkit_3.2.1-1_all.deb ...
Unpacking percona-toolkit (3.2.1-1) ...
Selecting previously unselected package unzip.
Preparing to unpack .../11-unzip_6.0-26ubuntu3.2_amd64.deb ...
Unpacking unzip (6.0-26ubuntu3.2) ...
Selecting previously unselected package libc6-dbg:amd64.
Preparing to unpack .../12-libc6-dbg_2.35-0ubuntu3.8_amd64.deb ...
Unpacking libc6-dbg:amd64 (2.35-0ubuntu3.8) ...
Setting up libdebuginfod-common (0.186-1build1) ...

Creating config file /etc/profile.d/debuginfod.sh with new version

Creating config file /etc/profile.d/debuginfod.csh with new version
Setting up unzip (6.0-26ubuntu3.2) ...
Setting up libdebuginfod1:amd64 (0.186-1build1) ...
Setting up libsource-highlight-common (3.1.9-4.1build2) ...
Setting up libc6-dbg:amd64 (2.35-0ubuntu3.8) ...
Setting up libboost-regex1.74.0:amd64 (1.74.0-14ubuntu3) ...
Setting up libipt2 (2.0.5-1) ...
Setting up libbabeltrace1:amd64 (1.5.8-2build1) ...
Setting up libdbi-perl:amd64 (1.643-3build3) ...
Setting up libsource-highlight4v5 (3.1.9-4.1build2) ...
Setting up gdb (12.1-0ubuntu1~22.04.2) ...
Setting up libdbd-mysql-perl:amd64 (4.050-5ubuntu0.22.04.1) ...
Setting up percona-toolkit (3.2.1-1) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
Processing triggers for man-db (2.10.2-1) ...
Scanning processes...
Scanning candidates...
Scanning linux images...

Restarting services...
 /etc/needrestart/restart.d/systemd-manager
 systemctl restart acpid.service chrony.service cron.service irqbalance.service multipathd.service mysql.service nginx.service packagekit.service pdns.service polkit.service rsyslog.service serial-getty@ttyS0.service ssh.service systemd-journald.service systemd-networkd.service systemd-resolved.service systemd-udevd.service
Service restarts being deferred:
 /etc/needrestart/restart.d/dbus.service
 systemctl restart getty@tty1.service
 systemctl restart networkd-dispatcher.service
 systemctl restart systemd-logind.service
 systemctl restart unattended-upgrades.service
 systemctl restart user@1000.service

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
asdf plugin add alp
initializing plugin repository...Cloning into '/home/isucon/.asdf/repository'...
remote: Enumerating objects: 6174, done.
remote: Counting objects: 100% (1852/1852), done.
remote: Compressing objects: 100% (66/66), done.
remote: Total 6174 (delta 1824), reused 1796 (delta 1786), pack-reused 4322 (from 1)
Receiving objects: 100% (6174/6174), 1.42 MiB | 17.91 MiB/s, done.
Resolving deltas: 100% (3396/3396), done.
asdf install alp `asdf list-all alp | tail -1`
∗ Downloading and installing alp...
The installation was successful!
asdf global alp `asdf list-all alp | tail -1`
make: *** No rule to make target 'log.init', needed by 'init'.  Stop.
```