### PR TITLE
add make tail.error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ tail.nginx:
 tail.app:
 	sudo journalctl -u $(SERVICE_NAME) -f
 
+tail.error:
+	sudo journalctl -u $(SERVICE_NAME) -f | grep ERROR
+
 # mysql slow-log
 #
 # slow_query_log = 1


### PR DESCRIPTION
アプリのログをエラーログに絞って追いたい時があるので、grepつきtailも用意しておく。
-fオプション付きでパイプできるの知らなかった。
https://unix.stackexchange.com/questions/3229/grep-and-tail-f